### PR TITLE
Use internal Nullable annotation, allow drop sisu-inject from runtime dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,12 @@ limitations under the License.
       <version>1</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
       <version>0.9.0.M4</version>
-      <scope>provided</scope>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/codehaus/plexus/velocity/internal/DefaultVelocityComponent.java
+++ b/src/main/java/org/codehaus/plexus/velocity/internal/DefaultVelocityComponent.java
@@ -25,7 +25,6 @@ import java.util.Properties;
 import org.apache.velocity.app.VelocityEngine;
 import org.codehaus.plexus.velocity.VelocityComponent;
 import org.codehaus.plexus.velocity.VelocityComponentConfigurator;
-import org.eclipse.sisu.Nullable;
 
 /**
  * Default component implementation. The presence of {@link VelocityComponentConfigurator} is optional.

--- a/src/main/java/org/codehaus/plexus/velocity/internal/Nullable.java
+++ b/src/main/java/org/codehaus/plexus/velocity/internal/Nullable.java
@@ -1,0 +1,18 @@
+package org.codehaus.plexus.velocity.internal;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Internal <code>Nullable</code> annotation to mark parameters that can be null.
+ * <p>
+ * Guice allow any Nullable annotation, so this one can be used instead of adding a dependency to sisu-inject.
+ * <a href="https://github.com/google/guice/wiki/UseNullable">UseNullable</a>
+ */
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@interface Nullable {}


### PR DESCRIPTION

org.eclipse.sisu.inject is not exported by Maven Core ... 
so plugins must add it to own dependency only for this one annotation

Own implementation avoid such situation